### PR TITLE
Fix for dns error

### DIFF
--- a/glogging/glogging.py
+++ b/glogging/glogging.py
@@ -183,5 +183,7 @@ def getLoggerFromPath(logpath="/dev/null/growthintel", **kwargs):
 
 def ensure_path_exists(path):
     dir = os.path.dirname(path)
-    if not os.path.exists(dir):
+    try:
         os.makedirs(dir)
+    except OSError:
+        pass

--- a/py2requirements.txt
+++ b/py2requirements.txt
@@ -1,1 +1,2 @@
 psutil==5.6.6
+pytest-mock==3.6.1

--- a/py2requirements.txt
+++ b/py2requirements.txt
@@ -1,2 +1,2 @@
 psutil==5.6.6
-pytest-mock==3.6.1
+pytest-mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ else:
     requirements += py3_requirements
 
 setup(name='glogging',
-      version='0.5.2',
+      version='0.5.3',
       description='GI logger',
       classifiers=['Programming Language :: Python :: 2.7',
                    'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from setuptools import setup
 requirements = []
 
 py3_requirements = [
-    'psutil==5.6.6'
+    'psutil==5.6.6',
+    'pytest-mock==3.6.1'
 ]
 
 if sys.version_info[0] == 2:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,32 @@
+import os
+from unittest.mock import MagicMock, patch
+from glogging.glogging import ensure_path_exists
+
+
+def test_ensure_path_exists_works():
+    # Define the directory path to create
+    dir_path = "test_directory"
+
+    # Mock os.makedirs
+    with patch("os.makedirs") as mock_makedirs:
+        # Call the os.makedirs with the mock in place
+        os.makedirs(dir_path)
+
+        # Check if the mock was called with the correct arguments
+        mock_makedirs.assert_called_once_with(dir_path)
+
+
+def test_ensure_path_exists_handles_oserror():
+    # Define the directory path to create
+    dir_path = "test_directory"
+    path = os.path.join(dir_path, "dummy_file")
+
+    # Mock os.makedirs to raise OSError after the first call
+    with patch("os.makedirs", side_effect=[None, None]) as mock_makedirs:
+        # Call the ensure_path_exists function twice
+        ensure_path_exists(path)
+        ensure_path_exists(path)
+
+        # Check if the mock was called twice with the correct arguments
+        assert mock_makedirs.call_count == 2
+        mock_makedirs.assert_called_with(dir_path)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,32 +1,20 @@
 import os
-from unittest.mock import MagicMock, patch
+import pytest
 from glogging.glogging import ensure_path_exists
 
 
-def test_ensure_path_exists_works():
-    # Define the directory path to create
-    dir_path = "test_directory"
-
-    # Mock os.makedirs
-    with patch("os.makedirs") as mock_makedirs:
-        # Call the os.makedirs with the mock in place
-        os.makedirs(dir_path)
-
-        # Check if the mock was called with the correct arguments
-        mock_makedirs.assert_called_once_with(dir_path)
-
-
-def test_ensure_path_exists_handles_oserror():
+def test_ensure_path_exists_handles_oserror(mocker):
     # Define the directory path to create
     dir_path = "test_directory"
     path = os.path.join(dir_path, "dummy_file")
 
     # Mock os.makedirs to raise OSError after the first call
-    with patch("os.makedirs", side_effect=[None, None]) as mock_makedirs:
-        # Call the ensure_path_exists function twice
-        ensure_path_exists(path)
-        ensure_path_exists(path)
+    mock_makedirs = mocker.patch("os.makedirs", side_effect=[None, None])
 
-        # Check if the mock was called twice with the correct arguments
-        assert mock_makedirs.call_count == 2
-        mock_makedirs.assert_called_with(dir_path)
+    # Call the ensure_path_exists function twice
+    ensure_path_exists(path)
+    ensure_path_exists(path)
+
+    # Check if the mock was called twice with the correct arguments
+    assert mock_makedirs.call_count == 2
+    mock_makedirs.assert_called_with(dir_path)


### PR DESCRIPTION
I think the issue with the dns flow was that multiple threads were getting past the if statement, and then trying to create the file. Likely due to the concurrency (if I am understanding how it all works correctly). This might be why it doesn't always fail as it could be rare to hit this race condition. So the fix should be letting them all create the file and just ignoring the issue if it comes up.